### PR TITLE
fix doc deployment

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           token: ${{ secrets.github_token }}
           branch: gh-pages
-          folder: docs/build/html
+          folder: doc/build/html
           clean: true
           single-commit: true
   


### PR DESCRIPTION
Simple fix to point to `doc` rather than `docs` for the deployment step.
