### PR TITLE
Include grantami-bomanalytics documentation approach

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -39,6 +39,7 @@ extensions = [
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev", None),
+    "grantami-bomanalytics": ("https://grantami.docs.pyansys.com", None),
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),
     # "matplotlib": ("https://matplotlib.org/stable", None),

--- a/doc/source/documentation_style/class_documentation.rst
+++ b/doc/source/documentation_style/class_documentation.rst
@@ -78,3 +78,32 @@ method or attribute on its own page.
    pyansys_sphinx_theme.samples.Complex.real
    pyansys_sphinx_theme.samples.Complex.imag
    pyansys_sphinx_theme.samples.Complex.abs
+
+
+Documenting Multiple Classes Together
+-------------------------------------
+
+To document a set of small but highly cohesive classes, an option
+is to combine the two approaches described above. This is done by
+including multiple ``autoclass`` directives on the same page with
+headings and text blocks as necessary to describe the
+relationships between the classes.
+
+For example, the Granta MI BoM Analytics
+:external+grantami-bomanalytics:doc:`Part Compliance page <api/compliance/parts>`
+first describes the
+:external+grantami-bomanalytics:class:`~ansys.grantami.bomanalytics.queries.PartComplianceQuery`
+class, and then describes the
+:external+grantami-bomanalytics:class:`~ansys.grantami.bomanalytics._query_results.PartComplianceQueryResult`,
+and
+:external+grantami-bomanalytics:class:`~ansys.grantami.bomanalytics._item_results.PartWithComplianceResult`
+classes returned by the query. The classes are only ever
+encountered together in this context, so they are documented on a
+single page.
+
+In contrast, the
+:external+grantami-bomanalytics:class:`~ansys.grantami.bomanalytics.indicators.RoHSIndicator`
+and
+:external+grantami-bomanalytics:class:`~ansys.grantami.bomanalytics.indicators.WatchListIndicator`
+classes are shared across multiple queries, and so they are
+documented separately.


### PR DESCRIPTION
This PR adds an extra section to the `Class Documentation` page that describes the approach taken for documenting the query and response objects in the grantami-bomanalytics packages.

Since there aren't any appropriate classes in the theme itself, I have included references to the classes in bomanalytics. If we decide this dependency is inappropriate I can come up with some additional example classes that are similar in style to the ones referenced here.