### PR TITLE
Fix broken links documentation practices

### DIFF
--- a/doc/source/guidelines/doc_practices.rst
+++ b/doc/source/guidelines/doc_practices.rst
@@ -148,7 +148,7 @@ For instance: `grantami <https://grantami.docs.pyansys.com>`_
 Regarding the documentation dedicated to a specific feature of the product or an example, the URL is formatted like this:
    ``<extra>.<product_name>.docs.pyansys.com``
 
-For instance: `cartpole <https://cartpole.mapdl.docs.pyansys.com>`_
+For instance: `cartpole <https://pyansys.github.io/ml-rl-cartpole/>`_
 
 Once the URL name has been decided, it must be specified in the "Settings -> Pages -> Custom domain" section of the repository.
 

--- a/doc/source/guidelines/doc_practices.rst
+++ b/doc/source/guidelines/doc_practices.rst
@@ -150,8 +150,7 @@ Regarding the documentation dedicated to a specific feature of the product or an
 
 For instance: `cartpole <https://cartpole.mapdl.docs.pyansys.com>`_
 
-Once the URL name has been decided, it must be specified in the "Settings" of the repository under the "Custom domain" section.
-For example, `see <https://github.com/pyansys/grantami-bomanalytics-docs/settings/pages>`_
+Once the URL name has been decided, it must be specified in the "Settings -> Pages -> Custom domain" section of the repository.
 
 Then, the URL has to be registered using Microsoft Azure to set the DNS properly and link it to the ANSYS organization.
 This action will be performed by one of the Ansys administrator of Microsoft Azure account.


### PR DESCRIPTION
This PR fixes a couple of broken links in the `Documentation practices` page.