### PR TITLE
Fix ansys-templates links

### DIFF
--- a/doc/source/library_description/template.rst
+++ b/doc/source/library_description/template.rst
@@ -18,9 +18,9 @@ the new project.
 Please, follow the `ansys-templates installation guide`_ to get the latest stable
 version installed in your system.
 
-- **Repository**: https://github.com/pyansys/pyansys-templates
-- **Documentation**: https://github.com/pyansys/pyansys-templates
-- **Issues board**: https://github.com/pyansys/pyansys-templates/issues
+- **Repository**: https://github.com/pyansys/ansys-templates
+- **Documentation**: https://github.com/pyansys/ansys-templates
+- **Issues board**: https://github.com/pyansys/ansys-templates/issues
 
 
 .. note::
@@ -81,7 +81,7 @@ Create a new project based on the ``pyansys-advanced`` template by running:
 .. _ansys-templates: https://templates.pyansys.com/index.html
 .. _ansys-templates installation guide: https://templates.pyansys.com/getting_started/index.html
 .. _ansys-templates user guide: https://templates.pyansys.com/user_guide/index.html
-.. _ansys-templates issues board:  https://github.com/pyansys/pyansys-templates/issues
+.. _ansys-templates issues board:  https://github.com/pyansys/ansys-templates/issues
 .. _flit: https://flit.readthedocs.io/en/latest/
 .. _poetry: https://python-poetry.org/
 .. _pre-commit: https://pre-commit.com/


### PR DESCRIPTION
Fixes links in [templates section] to properly point to the new renamed
[ansys-templates] repository

[templates section]: https://dev.docs.pyansys.com/library_description/template.html
[ansys-templates]: https://github.com/pyansys/ansys-templates
