### PR TITLE
Add Issues pages for Granta pubilc PyAnsys projects to Contributing page

### DIFF
--- a/doc/source/overview/contributing.rst
+++ b/doc/source/overview/contributing.rst
@@ -36,16 +36,16 @@ comment that explains why you have done so. If you need to contact the PyAnsys
 project support team directly, email `pyansys.support@ansys.com
 <pyansys.support@ansys.com>`_.
 
-For convenience, here are URLs for ``Issues`` pages for
-public Ansys repositories:
+For convenience, here are URLs for ``Issues`` pages for the
+public PyAnsys repositories:
 
-- `OpenAPI Common Issues <https://github.com/pyansys/openapi-common/issues>`_
 - `PyAEDT Issues <https://github.com/pyansys/pyaedt/issues>`_
 - `PyDPF-Core Issues <https://github.com/pyansys/pydpf-core/issues>`_
 - `PyDPF-Post Issues <https://github.com/pyansys/pydpf-post/issues>`_
 - `PyMAPDL Issues <https://github.com/pyansys/pymapdl/issues>`_
 - `PyMAPDL-Reader Issues <https://github.com/pyansys/pymapdl-reader/issues>`_
-
+- `OpenAPI Common Issues <https://github.com/pyansys/openapi-common/issues>`_
+- `Granta MI BoM Analytics Issues <https://github.com/pyansys/grantami-bomanalytics/issues>'_
 
 Submitting Questions
 --------------------

--- a/doc/source/overview/contributing.rst
+++ b/doc/source/overview/contributing.rst
@@ -45,7 +45,7 @@ public PyAnsys repositories:
 - `PyMAPDL Issues <https://github.com/pyansys/pymapdl/issues>`_
 - `PyMAPDL-Reader Issues <https://github.com/pyansys/pymapdl-reader/issues>`_
 - `OpenAPI Common Issues <https://github.com/pyansys/openapi-common/issues>`_
-- `Granta MI BoM Analytics Issues <https://github.com/pyansys/grantami-bomanalytics/issues>'_
+- `Granta MI BoM Analytics Issues <https://github.com/pyansys/grantami-bomanalytics/issues>`_
 
 Submitting Questions
 --------------------


### PR DESCRIPTION
@Andy-Grigg 
I moved the Issues entry for openapi-common beneath the five main PyAnsys libraries and then added a link for grantami-bomanalytics. However, I didn't add a link to the Issues page for grantami-bomanalytics-openapi because the Readme for this public library said that direct use was unsupported. 