### PR TITLE
Always deploy our web documentation

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -52,7 +52,6 @@ jobs:
           echo "dev.docs.pyansys.com" > doc/build/html/CNAME
 
       - name: Deploy to gh-pages on main
-        if: github.ref == 'refs/heads/main'
         uses: JamesIves/github-pages-deploy-action@4.1.5
         with:
           token: ${{ secrets.github_token }}


### PR DESCRIPTION
Let's change back to always deploying our web documentation.

I'd really like to have versioned docs, using the built in `pydata-sphinx-theme`, but until that point let's always keep our dev docs on latest.