### PR TITLE
Update guidelines on doc deploy

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -57,7 +57,7 @@ jobs:
           sudo apt update
           sudo apt-get install -y texlive-latex-extra latexmk
           python -m pip install -r requirements/requirements_doc.txt
-          make -C doc latexpdf
+          make -C doc pdf
 
       - name: Upload HTML documentation
         uses: actions/upload-artifact@v2.2.4
@@ -70,7 +70,7 @@ jobs:
         uses: actions/upload-artifact@v2.2.4
         with:
           name: PDF-Documentation
-          path: doc/build/latex/*.pdf
+          path: doc/build/latex/pyansys*.pdf
           retention-days: 7
 
       - name: Deploy to gh-pages

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -22,3 +22,9 @@ help:
 # customized clean due to examples gallery
 clean:
 	rm -rf build
+
+# customized pdf fov svg format images
+pdf:
+	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	cd build/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
+	(test -f build/latex/ansys_sphinx*.pdf && echo pdf exists) || exit 1

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -27,4 +27,4 @@ clean:
 pdf:
 	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 	cd build/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
-	(test -f build/latex/ansys_sphinx*.pdf && echo pdf exists) || exit 1
+	(test -f build/latex/pyansys*.pdf && echo pdf exists) || exit 1

--- a/doc/make.bat
+++ b/doc/make.bat
@@ -12,6 +12,7 @@ set SOURCEDIR=source
 set BUILDDIR=build
 
 if "%1" == "" goto help
+if "%1" == "pdf" goto pdf
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (
@@ -31,6 +32,12 @@ goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:pdf
+	%SPHINXBUILD% -M latex %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	cd "%BUILDDIR%\latex"
+	for %%f in (*.tex) do (
+	pdflatex "%%f" --interaction=nonstopmode)
 
 :end
 popd

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -63,8 +63,6 @@ source_suffix = ".rst"
 # The master toctree document.
 master_doc = "index"
 
-latex_elements = {}
-
 # Grouping the document tree into LaTeX files. List of tuples
 # (source start file, target name, title,
 #  author, documentclass [howto, manual, or own class]).

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,7 +1,14 @@
 """Sphinx documentation configuration file for the pyansys developer's guide."""
 from datetime import datetime
 
-from ansys_sphinx_theme import __version__, pyansys_logo_black
+from ansys_sphinx_theme import (
+    __version__,
+    ansys_logo_white,
+    ansys_logo_white_cropped,
+    pyansys_logo_black,
+    watermark,
+)
+from ansys_sphinx_theme.latex import generate_preamble
 
 # Project information
 project = "PyAnsys Developer's Guide"
@@ -118,3 +125,7 @@ autosectionlabel_maxdepth = 4
 # TODO: warning suppression is temporary till https://github.com/pyansys/dev-guide/issues/64
 # gets fully implemented.
 suppress_warnings = ["autosectionlabel.*"]
+
+# Generate the LaTeX preamble
+latex_additional_files = [watermark, ansys_logo_white, ansys_logo_white_cropped]
+latex_elements = {"preamble": generate_preamble(html_title)}

--- a/doc/source/how-to/diag/doc_layout.rst
+++ b/doc/source/how-to/diag/doc_layout.rst
@@ -1,8 +1,8 @@
+.. _proposed doc layout
 .. graphviz::
     :caption: Generic structure for the PyAnsys library documentation.
     :alt: Generic structure for the PyAnsys library documentation.
     :align: center
-    :name: propsed doc layout
 
      digraph "sphinx-ext-graphviz" {
          size="8,6";

--- a/doc/source/how-to/diag/doc_layout.rst
+++ b/doc/source/how-to/diag/doc_layout.rst
@@ -1,4 +1,4 @@
-.. _proposed_doc_layout:
+.. _proposed doc layout:
 .. graphviz::
     :caption: Generic structure for the PyAnsys library documentation.
     :alt: Generic structure for the PyAnsys library documentation.

--- a/doc/source/how-to/diag/doc_layout.rst
+++ b/doc/source/how-to/diag/doc_layout.rst
@@ -1,4 +1,4 @@
-.. _proposed doc layout
+.. _proposed doc layout:
 .. graphviz::
     :caption: Generic structure for the PyAnsys library documentation.
     :alt: Generic structure for the PyAnsys library documentation.

--- a/doc/source/how-to/diag/doc_layout.rst
+++ b/doc/source/how-to/diag/doc_layout.rst
@@ -1,8 +1,8 @@
-.. _proposed doc layout:
 .. graphviz::
     :caption: Generic structure for the PyAnsys library documentation.
     :alt: Generic structure for the PyAnsys library documentation.
     :align: center
+    :name: propsed doc layout
 
      digraph "sphinx-ext-graphviz" {
          size="8,6";

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -530,7 +530,7 @@ with:
                 retention-days: 7
 
 This allows anyone creating pull requests to download documentation build
-artifacts as a convenient zip and to open the documentation by opening
+artifacts as a convenient zip file and to open the documentation by opening
 ``index.html``.
 
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -534,8 +534,21 @@ This allows anyone creating pull requests to download documentation build
 artifacts as a convenient zip and to open the documentation by opening
 ``index.html``.
 
+
+Deploying to GitHub Pages
++++++++++++++++++++++++++
 Next, deploy your documentation to the ``gh-pages`` branch via using the
-``JamesIves/github-pages-deploy-action`` action:
+``JamesIves/github-pages-deploy-action`` action.
+
+.. admonition:: Deploying to another repository.
+
+   If you are planning to deploy documentation to another repository rather than
+   the one for your project, make sure you create this new repo before deploying
+   for the first time your documentation.
+
+The following job step shows the logic for deploying. If you wish to deploy to
+another repository, make sure to uncomment the ``repository-name`` line and
+declare the name of your documentation repository:
 
 .. tabs::
 
@@ -548,6 +561,7 @@ Next, deploy your documentation to the ``gh-pages`` branch via using the
               uses: JamesIves/github-pages-deploy-action@4.3.0
               with:
                 github-token: ${{ secrets.GITHUB_TOKEN }}
+                # repository-name: pyansys/repository-name
                 branch: gh-pages
                 folder: .tox/doc_out
                 clean: true
@@ -561,6 +575,7 @@ Next, deploy your documentation to the ``gh-pages`` branch via using the
               uses: JamesIves/github-pages-deploy-action@4.3.0
               with:
                 github-token: ${{ secrets.GITHUB_TOKEN }}
+                # repository-name: pyansys/repository-name
                 branch: gh-pages
                 folder: doc/_build/html
                 clean: true
@@ -601,7 +616,8 @@ repositories you have access to.
 Paste the value of the token in the ``Settings/Secrets/Actions`` path under a
 new secret named ``GITHUB_TOKEN`` in the repository of the project.
 
-.. note::
+Deploying when Tagging
+++++++++++++++++++++++
 
    Depending on your preferences, you may choose to update the documentation on
    tags only (as done above), or on each each push. If you wish to have your

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -609,7 +609,7 @@ some repositories and can be used for this purpose.
 
 .. admonition:: Organization approval to use PyAnsys bot
 
-    You need internal approval to use PyAnsys bot as your repo needs to added to
+    You need internal approval to use PyAnsys bot as your repo needs to be added to
     its list of repositories.
     Please email `PyAnsys Support <pyansys.support@ansys.com>`_.
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -68,14 +68,13 @@ Directory` directory. The ``index.rst`` file in the ``doc/source`` directory
 defines the first level of your documentation hierarchy.  The ``toctree``
 directive (which stands for "table of contents tree") indicates the maximum
 number of heading levels that the documentation is to display. Below this
-directive are the directory names for your documentation sections.  Each
-documentation chapter has its own ``index.rst`` file, as shown by figure
-:numref:`proposed doc layout`.
+directive are the directory names for your documentation sections.
 
 .. include:: diag/doc_layout.rst
 
-Previous documentation layout can be modelled using the following code in each
-one of the ``index.rst`` files.
+Each documentation chapter has its own ``index.rst`` file, as shown by figure
+:numref:`proposed doc layout`. Previous documentation layout can be modelled
+using the following code in each one of the ``index.rst`` files.
 
 .. tabs::
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -536,7 +536,7 @@ artifacts as a convenient zip and to open the documentation by opening
 
 Deploying to GitHub Pages
 +++++++++++++++++++++++++
-Next, deploy your documentation to the ``gh-pages`` branch via using the
+Next, deploy your documentation to the ``gh-pages`` branch with:
 `JamesIves/github-pages-deploy-action
 <https://github.com/JamesIves/github-pages-deploy-action>`_ action.
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -439,7 +439,7 @@ certain conditions.
 
 Documentation Workflow
 ++++++++++++++++++++++
-Your documentation workflow should be within the ``.github/workflows``
+Your documentation workflow should be in the ``.github/workflows``
 directory and should be triggered on each PR. It should use one of the
 following approaches:
 
@@ -447,7 +447,7 @@ following approaches:
 
     .. group-tab:: Using ``tox``
 
-        The best way to get started with this is to use the `ansys-templates`_ tool and run:
+        The best way to get started with ``tox`` is to use the `ansys-templates`_ tool and run:
 
         .. code-block:: text
 
@@ -475,7 +475,7 @@ following approaches:
     .. group-tab:: Without Using ``tox``
 
         While `tox`_ is the preferred tool for automating your documentation build, if
-        you wish to avoid using `tox`_, consider the following workflow:
+        you want to avoid using `tox`_, consider the following workflow:
 
         .. code-block:: yaml
 
@@ -530,7 +530,7 @@ with:
                 path: doc/_build/html
                 retention-days: 7
 
-This will allow anyone creating pull requests to download documentation build
+This allows anyone creating pull requests to download documentation build
 artifacts as a convenient zip and to open the documentation by opening
 ``index.html``.
 
@@ -566,13 +566,14 @@ Next, deploy your documentation to the ``gh-pages`` branch via using the
                 clean: true
 
 Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. This repo
-needs ``write`` rights and SSO access if you plan to deploy to the ``gh-pages``
-of another branch.
+needs ``write`` permission and SSO access if you plan to deploy to the ``gh-pages``
+or to another branch.
 
 To create the ``TOKEN``, go to the ``Settings`` section in your GitHub profile.
 In the left side bar, select the ``Developer Settings`` section and then
-``Personal access tokens``. Finally, click on ``Generate new token`` and give it
+``Personal access tokens``. Finally, click ``Generate new token`` and give it
 ``write`` permissions. You will be prompted with the value of the ``TOKEN``.
+Make sure to copy the value of the ``TOKEN`` as you will not be able to retrieve it later.
 Finally, click on ``Configure SSO`` to allow using it with the PyAnsys
 repositories you have access to.
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -589,7 +589,7 @@ do it.
 
 In that case, there are two options for documentation deployment, using a bot
 and using a personal access token (PAT). Depending on your profile (how many
-organizations you work in, the rights in the different repositories, etc), using
+organizations you work in, the rights in the different repositories, etc.), using
 a PAT can be potentially dangerous because PAT are not restricted to defined
 repositories, rather have general permissions. This means that a PAT with
 `repository-write` permission can write in any repo in any organization that the

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -72,9 +72,9 @@ directive are the directory names for your documentation sections.
 
 .. include:: diag/doc_layout.rst
 
-Each documentation chapter has its own ``index.rst`` file, as shown by figure
-:numref:`proposed doc layout`. Previous documentation layout can be modelled
-using the following code in each one of the ``index.rst`` files.
+Each documentation chapter has its own ``index.rst`` file, as shown by previous
+figure. The documentation layout can be modelled using the following code in
+each one of the ``index.rst`` files.
 
 .. tabs::
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -679,7 +679,7 @@ Additionally, you must add the following code for the documentation deployment:
 
 
 Deploying by Using a Personal Access Token
-"""""""""""""""""""""""""""""""""""""""""
+""""""""""""""""""""""""""""""""""""""""""
 To set up the documentation deployment using a Personal Access Token (PAT), you
 must first create a PAT in the ``Settings`` section in your
 GitHub profile. In the left side bar, select the ``Developer Settings`` section

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -581,7 +581,7 @@ declare the name of your documentation repository:
                 clean: true
 
 
-Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. Github
+Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. GitHub
 automatically generates the token ``GITHUB_TOKEN`` which you can use as
 ``token`` for deploying documentation to the same repo. However, if you are
 planning to deploy to another repo this token does not have the permissions to

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -546,7 +546,7 @@ Next, deploy your documentation to the ``gh-pages`` branch with:
    the one for your project, make sure you create this new repo before deploying
    for the first time your documentation.
 
-The following job step shows the logic for deploying. If you wish to deploy to
+The following job step shows the logic for deploying. If you want to deploy to
 another repository, make sure to uncomment the ``repository-name`` line and
 declare the name of your documentation repository:
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -67,12 +67,12 @@ editor to create ReStructured Text (RST) files that you then place in :ref:`The 
 Directory` directory. The ``index.rst`` file in the ``doc/source`` directory
 defines the first level of your documentation hierarchy.  The ``toctree``
 directive (which stands for "table of contents tree") indicates the maximum
-number of heading levels that the documentation is to display. Below this
+number of heading levels that the documentation is to display. Following this
 directive are the directory names for your documentation sections.
 
 .. include:: diag/doc_layout.rst
 
-Each documentation chapter has its own ``index.rst`` file, as shown by previous
+Each documentation chapter has its own ``index.rst`` file, as shown by the preceding
 figure. The documentation layout can be modeled using the following code in
 each one of the ``index.rst`` files.
 
@@ -542,9 +542,9 @@ Next, deploy your documentation to the ``gh-pages`` branch with:
 
 .. admonition:: Deploying to another repository.
 
-   If you are planning to deploy documentation to another repository rather than
-   the one for your project, make sure you create this new repo before deploying
-   for the first time your documentation.
+   If you are planning to deploy documentation to repository other than
+   the one for your project, make sure you create this new repository before deploying
+   your documentation for the first time.
 
 The following job step shows the logic for deploying. If you want to deploy to
 another repository, make sure to uncomment the ``repository-name`` line and
@@ -583,39 +583,38 @@ declare the name of your documentation repository:
 
 Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. GitHub
 automatically generates the token ``GITHUB_TOKEN`` which you can use as
-``token`` for deploying documentation to the same repo. However, if you are
-planning to deploy to another repo this token does not have the permissions to
-do it.
+``token`` for deploying documentation to the same repository. However, if you are
+planning to deploy to another repository, this token does not have the necessary permissions.
 
-In that case, there are two options for documentation deployment, using a bot
-and using a personal access token (PAT). Depending on your profile (how many
-organizations you work in, the rights in the different repositories, etc.), using
-a PAT can be potentially dangerous because PAT are not restricted to defined
-repositories, rather have general permissions. This means that a PAT with
-`repository-write` permission can write in any repo in any organization that the
+In this case, there are two options for documentation deployment, using a bot
+and using a personal access token (PAT). Depending on your profile (such as how many
+organizations you work in and your permissions for different repositories), using
+a PAT can be potentially dangerous because a PAT is not restricted to defined
+repositories but rather has general permissions. This means that a PAT with
+`repository-write` permission can write in any repository in any organization that the
 PAT creator can access.
 
-Therefore, the recommended approach is to **use a Bot**. However, you are free
-to use a PAT if you feel it fits your needs better.
+Therefore, the recommended approach is to **use a bot**. However, you can use a
+PAT if you feel it fits your needs better.
 
 
 Deploying by Using a Bot
 """"""""""""""""""""""""
-To deploy documentation to repo different than the one where the documentation
-is generated, you need permissions to access (*read/write*) this second repo.
-These permissions can be handled using a specifically created bot. In PyAnsys
-organization, there is `PyAnsys Bot`_ which has read and write permission across
+To deploy documentation to a repository other than the one where the documentation
+is generated, you must have permissions to access (*read/write*) this second repository.
+These permissions can be handled using a specifically created bot. In the PyAnsys
+organization, there is `PyAnsys Bot`_, which has read and write permission across
 some repositories and can be used for this purpose.
 
 .. admonition:: Organization approval to use PyAnsys bot
 
-    You need internal approval to use PyAnsys bot as your repo needs to be added to
-    its list of repositories.
-    Please email `PyAnsys Support <pyansys.support@ansys.com>`_.
+    You must have internal approval to use the PyAnsys bot because your repository must
+    be added to its list of repositories. For more information, email
+    `PyAnsys Support <pyansys.support@ansys.com>`_.
 
 
-Once your repository has been added to the bot repositories white-list, you need to add the
-following code to your CICD YAML file for the authentication:
+Once your repository has been added to the white-list for the the bot repositories, you must
+add the following code to your CICD YAML file for the authentication:
 
 .. tabs::
 
@@ -645,7 +644,7 @@ following code to your CICD YAML file for the authentication:
               application_private_key: ${{ secrets.BOT_APPLICATION_PRIVATE_KEY }}
 
 
-and the following for the documentation deployment:
+Additionally, you must add the following code for the documentation deployment:
 
 .. tabs::
 
@@ -679,15 +678,15 @@ and the following for the documentation deployment:
 
 
 
-Deployin by Using a Personal Access Token
+Deploying by Using a Personal Access Token
 """""""""""""""""""""""""""""""""""""""""
-To setup the documentation deployment using a Personal Access Token (PAT), you
-need to create a personal access token first in the ``Settings`` section in your
+To set up the documentation deployment using a Personal Access Token (PAT), you
+must first create a PAT in the ``Settings`` section in your
 GitHub profile. In the left side bar, select the ``Developer Settings`` section
 and then ``Personal access tokens``. Finally, click ``Generate new token`` and
-give it ``write`` permissions on ``Repositories`` at least. You will be prompted
+give it ``write`` permissions on ``Repositories`` at least. You are then prompted
 with the value of the ``TOKEN``. Make sure to copy the value of the ``TOKEN`` as
-you will not be able to retrieve it later. Finally, click ``Configure SSO`` to
+you are not be able to retrieve it later. Finally, click ``Configure SSO`` to
 allow using it with the PyAnsys repositories you have access to.
 
 .. note::
@@ -750,9 +749,9 @@ secret in your CI/CD:
 Deploying when Tagging
 ++++++++++++++++++++++
 
-Depending on your preferences, you may choose to update the documentation on
-tags only (as done above), or on each push. If you wish to have your
-documentation deployed on each push to ``main``, change the conditional above
+Depending on your preferences, you can choose to update the documentation on
+tags only (as done earlier) or on each push. If you want to have your
+documentation deployed on each push to ``main``, change the preceding conditional
 to:
 
 .. code-block:: yaml

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -70,12 +70,12 @@ directive (which stands for "table of contents tree") indicates the maximum
 number of heading levels that the documentation is to display. Below this
 directive are the directory names for your documentation sections.  Each
 documentation chapter has its own ``index.rst`` file, as shown by figure
-:numref:`proposed_doc_layout`.
+:numref:`proposed doc layout`.
 
 .. include:: diag/doc_layout.rst
 
-The documentation structure shown in :numref:`proposed_doc_layout` can be modelled
-using the following code in each one of the ``index.rst`` files.
+Previous documentation layout can be modelled using the following code in each
+one of the ``index.rst`` files.
 
 .. tabs::
 
@@ -538,7 +538,8 @@ artifacts as a convenient zip and to open the documentation by opening
 Deploying to GitHub Pages
 +++++++++++++++++++++++++
 Next, deploy your documentation to the ``gh-pages`` branch via using the
-`JamesIves/github-pages-deploy-action <https://github.com/JamesIves/github-pages-deploy-action>`_ action.
+`JamesIves/github-pages-deploy-action
+<https://github.com/JamesIves/github-pages-deploy-action>`_ action.
 
 .. admonition:: Deploying to another repository.
 
@@ -580,31 +581,32 @@ declare the name of your documentation repository:
                 folder: doc/_build/html
                 clean: true
 
-Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. 
-Github automatically generates the token ``GITHUB_TOKEN`` which you can use as ``token``
-for deploying documentation to the same repo.
-However, if you are planning to deploy to another repo this token does not have the
-permissions to do it.
 
-In that case, there are two options for documentation deployment, using a bot and using
-a personal access token (PAT).
-Depending on your profile (how many organizations you work in, the rights in the different
-repositories, etc), using a PAT can be potentially dangerous because PAT are not restricted
-to defined repositories, rather have general permissions.
-This means that a PAT with `repository-write` permission can write in any repo in any
-organization that the PAT creator can access.
+Notice that for previous job steps, a ``GITHUB_TOKEN`` is required. Github
+automatically generates the token ``GITHUB_TOKEN`` which you can use as
+``token`` for deploying documentation to the same repo. However, if you are
+planning to deploy to another repo this token does not have the permissions to
+do it.
 
-Therefore, the recommended approach is to **use a Bot**. However, you are free to use a PAT
-if you feel it fits your needs better.
+In that case, there are two options for documentation deployment, using a bot
+and using a personal access token (PAT). Depending on your profile (how many
+organizations you work in, the rights in the different repositories, etc), using
+a PAT can be potentially dangerous because PAT are not restricted to defined
+repositories, rather have general permissions. This means that a PAT with
+`repository-write` permission can write in any repo in any organization that the
+PAT creator can access.
 
-**Documentation Deployment using a bot**
+Therefore, the recommended approach is to **use a Bot**. However, you are free
+to use a PAT if you feel it fits your needs better.
 
-To deploy documentation to repo different than the one where the documentation is generated,
-you need permissions to access (*read/write*) this second repo. 
-These permissions can be handled using a specifically created bot.
-In PyAnsys organization, there is
-`PyAnsys bot <https://github.com/organizations/pyansys/settings/installations/22012868>`_
-which has read and write permission across some repositories and can be used for this purpose.
+
+Deploying by Using a Bot
+""""""""""""""""""""""""
+To deploy documentation to repo different than the one where the documentation
+is generated, you need permissions to access (*read/write*) this second repo.
+These permissions can be handled using a specifically created bot. In PyAnsys
+organization, there is `PyAnsys Bot`_ which has read and write permission across
+some repositories and can be used for this purpose.
 
 .. admonition:: Organization approval to use PyAnsys bot
 
@@ -677,23 +679,23 @@ and the following for the documentation deployment:
                 clean: true
 
 
-**Documentation Deployment using a Personal Access Token (PAT)**
 
-To setup the documentation deployment using a PAT, you need to 
-create a personal access token first in the ``Settings`` section in your GitHub profile.
-In the left side bar, select the ``Developer Settings`` section and then
-``Personal access tokens``. Finally, click ``Generate new token`` and give it
-``write`` permissions on ``Repositories`` at least. 
-You will be prompted with the value of the ``TOKEN``.
-Make sure to copy the value of the ``TOKEN`` as you will not be able to retrieve it later.
-Finally, click ``Configure SSO`` to allow using it with the PyAnsys
-repositories you have access to.
+Deployin by Using a Personal Access Token
+"""""""""""""""""""""""""""""""""""""""""
+To setup the documentation deployment using a Personal Access Token (PAT), you
+need to create a personal access token first in the ``Settings`` section in your
+GitHub profile. In the left side bar, select the ``Developer Settings`` section
+and then ``Personal access tokens``. Finally, click ``Generate new token`` and
+give it ``write`` permissions on ``Repositories`` at least. You will be prompted
+with the value of the ``TOKEN``. Make sure to copy the value of the ``TOKEN`` as
+you will not be able to retrieve it later. Finally, click ``Configure SSO`` to
+allow using it with the PyAnsys repositories you have access to.
 
 .. note::
 
-    In some cases, the authentication might need specific approval. 
-    If you do still get authentication errors like those that follow,
-    click the link in the log to authorize the workflow.
+    In some cases, the authentication might need specific approval. If you do
+    still get authentication errors like those that follow, click the link in
+    the log to authorize the workflow.
     
     .. code-block:: text
         :emphasize-lines: 1,2,9
@@ -711,8 +713,8 @@ repositories you have access to.
       
 
 Paste the value of the token in the ``Settings/Secrets/Actions`` path under a
-new secret named ``DEPLOY_DOCS_PAT`` in the repository of the project.
-Use this secret in your CI/CD:
+new secret named ``DEPLOY_DOCS_PAT`` in the repository of the project. Use this
+secret in your CI/CD:
 
 .. tabs::
 
@@ -749,21 +751,21 @@ Use this secret in your CI/CD:
 Deploying when Tagging
 ++++++++++++++++++++++
 
-   Depending on your preferences, you may choose to update the documentation on
-   tags only (as done above), or on each each push. If you wish to have your
-   documentation deployed on each push to ``main``, change the conditional
-   above to:
+Depending on your preferences, you may choose to update the documentation on
+tags only (as done above), or on each each push. If you wish to have your
+documentation deployed on each push to ``main``, change the conditional above
+to:
 
-   .. code-block:: yaml
+.. code-block:: yaml
 
-       if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
 
 
 Accessing Online Documentation
 ------------------------------
 Documentation for the latest stable release of a PyAnsys library is accessible
-from its repository. You can generally access the latest development version of the
-documentation tracking the ``main`` branch by adding the prefix ``dev.`` to
+from its repository. You can generally access the latest development version of
+the documentation tracking the ``main`` branch by adding the prefix ``dev.`` to
 the URL for the latest stable release.
 
 For example, consider PyAEDT documentation:

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -394,7 +394,7 @@ To  build ``PDF`` documentation, the following rules must be added to
            :pdf
                    %SPHINXBUILD% -M latex %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
 	           cd "%BUILDDIR%\latex"
-	           pdflatex *.tex --interaction=nonstopmode
+	           pdflatex \*.tex --interaction=nonstopmode
 
 You can call previous rules by running:
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -751,7 +751,7 @@ Deploying when Tagging
 ++++++++++++++++++++++
 
 Depending on your preferences, you may choose to update the documentation on
-tags only (as done above), or on each each push. If you wish to have your
+tags only (as done above), or on each push. If you wish to have your
 documentation deployed on each push to ``main``, change the conditional above
 to:
 

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -73,7 +73,7 @@ directive are the directory names for your documentation sections.
 .. include:: diag/doc_layout.rst
 
 Each documentation chapter has its own ``index.rst`` file, as shown by previous
-figure. The documentation layout can be modelled using the following code in
+figure. The documentation layout can be modeled using the following code in
 each one of the ``index.rst`` files.
 
 .. tabs::

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -574,8 +574,29 @@ In the left side bar, select the ``Developer Settings`` section and then
 ``Personal access tokens``. Finally, click ``Generate new token`` and give it
 ``write`` permissions. You will be prompted with the value of the ``TOKEN``.
 Make sure to copy the value of the ``TOKEN`` as you will not be able to retrieve it later.
-Finally, click on ``Configure SSO`` to allow using it with the PyAnsys
+Finally, click ``Configure SSO`` to allow using it with the PyAnsys
 repositories you have access to.
+
+.. note::
+
+    In some cases, the authentication might need specific approval. 
+    If you do still get authentication errors like those that follow,
+    click the link in the log to authorize the workflow.
+    
+    .. code-block:: text
+        :emphasize-lines: 1,2,9
+        
+        remote: The `pyansys' organization has enabled or enforced SAML SSO. To access
+        remote: this repository, visit https://github.com/orgs/pyansys/sso?            authorization_request=AGWYQUM5VKPHAQHRS2H3JNTCVBNE7A5PN5ZGOYLONF5GC5DJN5XF62LEZYB663VUVVRX      EZLEMVXHI2LBNRPWSZGOGU33VEFPMNZGKZDFNZ2GSYLML52HS4DFVNHWC5LUNBAWGY3FONZQ
+        remote: and try your request again.
+        fatal: unable to access 'https://github.com/pyansys/pynexus-dev-docs.git/': The requested URL returned error: 403
+        Running post deployment cleanup jobs… 🗑️
+        /usr/bin/git checkout -B github-pages-deploy-action/x00pqaqlu
+        Reset branch 'github-pages-deploy-action/x00pqaqlu'
+        /usr/bin/chmod -R 777 github-pages-deploy-action-temp-deployment-folder
+        /usr/bin/git worktree remove github-pages-deploy-action-temp-deployment-folder --force
+        Error: The deploy step encountered an error: The process '/usr/bin/git' failed with exit code 128 ❌
+      
 
 Paste the value of the token in the ``Settings/Secrets/Actions`` path under a
 new secret named ``GITHUB_TOKEN`` in the repository of the project.


### PR DESCRIPTION
Resolves #112 by adding:

- Guidelines on how to set up the TOKEN for doc deployment.
- Using group-tabs for switching between tox and raw doc workflows.