### PR TITLE
Correct the link to install Git on Windows .

### DIFF
--- a/doc/source/how-to/setting-up.rst
+++ b/doc/source/how-to/setting-up.rst
@@ -281,7 +281,7 @@ Installation
 
         To install Git on a machine running Windows:
         
-        1. Download the `latest stable standalone Git version for Windows <https://www.python.org/downloads/win/>`_.
+        1. Download the `latest stable standalone Git version for Windows <https://git-scm.com/download/win>`_.
         2. Execute the installer and follow the installation instructions.
 
     .. group-tab:: macOS


### PR DESCRIPTION
In the "How to" section of the documentation, the link for Git installation on Windows machine was pointing to Python org.

Fix #120  .