### PR TITLE
Use isort instead of import-reorder

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,25 +1,33 @@
 repos:
+
+
 - repo: https://github.com/psf/black
   rev: 22.3.0
   hooks:
   - id: black
-    exclude: "^({{cookiecutter.project_slug}}/)"
-- repo: https://github.com/asottile/reorder_python_imports
-  rev: v2.6.0
+    args: ["doc/source/conf.py"]
+
+- repo: https://github.com/pycqa/isort
+  rev: 5.10.1
   hooks:
-  - id: reorder-python-imports
-    args: ["--py37-plus"]
-    exclude: "^({{cookiecutter.project_slug}}/)"
+  - id: isort
+    args: [
+      "--profile", "black",
+      "--force-sort-within-sections",
+      "--line-length", "100",
+    ]
+
 - repo: https://gitlab.com/PyCQA/flake8
   rev: 3.9.2
   hooks:
   - id: flake8
-    exclude: "^({{cookiecutter.project_slug}}/)"
+
 - repo: https://github.com/codespell-project/codespell
   rev: v2.1.0
   hooks:
   - id: codespell
     args: [--ignore-words=ignore_words.txt, -S \*.pyc\,\*.xml\,\*.txt\,\*.gif\,\*.png\,\*.jpg\,\*.js\,\*.html\,\*.doctree\,\*.ttf\,\*.woff\,\*.woff2\,\*.eot\,\*.mp4\,\*.inv\,\*.pickle\,\*.ipynb\,flycheck\*\,./.git/\*\,./.hypothesis/\*\,\*.yml\,./doc/build/\*\,./doc/images/\*\,./dist/\*\,\*~\,.hypothesis\*\,./doc/source/examples/\*\,\*cover\,\*.dat\,\*.mac]
+
 - repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.1.0
   hooks:

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -1,8 +1,7 @@
 """Sphinx documentation configuration file for the pyansys developer's guide."""
 from datetime import datetime
 
-from ansys_sphinx_theme import __version__
-from ansys_sphinx_theme import pyansys_logo_black
+from ansys_sphinx_theme import __version__, pyansys_logo_black
 
 # Project information
 project = "PyAnsys Developer's Guide"

--- a/doc/source/how-to/code/pyansys_logging.py
+++ b/doc/source/how-to/code/pyansys_logging.py
@@ -1,12 +1,8 @@
-import logging
-import sys
 from copy import copy
 from datetime import datetime
-from logging import CRITICAL
-from logging import DEBUG
-from logging import ERROR
-from logging import INFO
-from logging import WARN
+import logging
+from logging import CRITICAL, DEBUG, ERROR, INFO, WARN
+import sys
 
 # Default configuration
 LOG_LEVEL = logging.DEBUG


### PR DESCRIPTION
This PR imposes "isort" as the main import style checker, similarly to other projects in the PyAnsys ecosystem.