### PR TITLE
Force white background in diagrams

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -115,7 +115,7 @@ exclude_patterns = [
 # Fix excessive margins in mermaid output.
 # See issue: https://github.com/mermaid-js/mermaid/issues/1800#issuecomment-741617143
 mermaid_output_format = "png"
-mermaid_params = ["--width", "2000"]
+mermaid_params = ["--width", "2000", "--backgroundColor", "white"]
 
 # Generate section labels up to four levels deep
 autosectionlabel_maxdepth = 4

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -117,6 +117,9 @@ exclude_patterns = [
 mermaid_output_format = "png"
 mermaid_params = ["--width", "2000", "--backgroundColor", "white"]
 
+# Graphviz diagrams configuration
+graphviz_output_format = "png"
+
 # Generate section labels up to four levels deep
 autosectionlabel_maxdepth = 4
 

--- a/doc/source/how-to/diag/doc_layout.rst
+++ b/doc/source/how-to/diag/doc_layout.rst
@@ -6,6 +6,7 @@
 
      digraph "sphinx-ext-graphviz" {
          size="8,6";
+         bgcolor="white"
          rankdir="LR";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"

--- a/doc/source/how-to/diag/main_branch.rst
+++ b/doc/source/how-to/diag/main_branch.rst
@@ -5,7 +5,7 @@
 
      digraph "sphinx-ext-graphviz" {
          size="8,6";
-         bgcolor="transparent";
+         bgcolor="white";
          rankdir="LR";
          node[width=0.15, height=0.15, shape=point, color=black];
          edge[weight=2, arrowhead=none, color=black];

--- a/doc/source/how-to/diag/release_branch.rst
+++ b/doc/source/how-to/diag/release_branch.rst
@@ -5,7 +5,7 @@
 
      digraph "sphinx-ext-graphviz" {
          size="8,6";
-         bgcolor="transparent";
+         bgcolor="white";
          rankdir="LR";
          node[width=0.15, height=0.15, shape=point, color=black];
          edge[weight=2, arrowhead=none, color=black];

--- a/doc/source/packaging/diag/doc_structure_diag.rst
+++ b/doc/source/packaging/diag/doc_structure_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"
          ];

--- a/doc/source/packaging/diag/grpc_structure_diag.rst
+++ b/doc/source/packaging/diag/grpc_structure_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white",splines=ortho
          ];

--- a/doc/source/packaging/diag/pyansys_namespace_diag.rst
+++ b/doc/source/packaging/diag/pyansys_namespace_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"
          ];

--- a/doc/source/packaging/diag/pyproduct_library_structure_diag.rst
+++ b/doc/source/packaging/diag/pyproduct_library_structure_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white", splines=ortho
          ];

--- a/doc/source/packaging/diag/python_library_diag.rst
+++ b/doc/source/packaging/diag/python_library_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="6,4";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"
          ];

--- a/doc/source/packaging/diag/src_structure_diag.rst
+++ b/doc/source/packaging/diag/src_structure_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"
          ];

--- a/doc/source/packaging/diag/tests_structure_diag.rst
+++ b/doc/source/packaging/diag/tests_structure_diag.rst
@@ -7,6 +7,7 @@
      digraph "sphinx-ext-graphviz" {
          size="8,6";
          rankdir="LR";
+         bgcolor="white";
          graph [
            fontname="Verdana", fontsize="10", color="black", fillcolor="white"
          ];


### PR DESCRIPTION
Solves for #143 by forcing a white background in mermaid diagrams.

<div align="center">
  <img src="https://user-images.githubusercontent.com/28702884/179295899-980a24ab-26cf-4eeb-8f3c-43812b7b3ff9.png">
</div>
