### PR TITLE
Docs/general enhancements

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,7 +2,8 @@
 PyAnsys Developer's Guide
 #########################
 
-The *PyAnsys Developer's Guide* is the central document for:
+The `PyAnsys Developer's Guide <https://dev.docs.pyansys.com>`_ is the central
+document for:
 
 - Ansys developers who want to create and "own" PyAnsys libraries
 - Anyone in the Python community who wants to contribute to a 
@@ -10,10 +11,11 @@ The *PyAnsys Developer's Guide* is the central document for:
 - Anyone who is interested in learning more about the PyAnsys 
   project and PyAnsys libraries
 
-A link to the web-based version of this `guide <https://dev.docs.pyansys.com>`_
-is available in the 'About' area for the `dev-guide <https://github.com/pyansys/dev-guide>`_
-repository. A link to a PDF version of this guide is available in the `Releases
-<https://github.com/pyansys/about/releases>`_ section under 'Assets'.
+A link to the latest web-based version of this guide is available in the **About**
+area of the repository. In the `Releases
+<https://github.com/pyansys/about/releases>`_ area of the repository, you can
+view information about all releases of this guide. In the **Assets**  area for
+any release, you can download a PDF of the guide for this release.
 
 This guide provides an overview that describes the PyAnsys project organization,
 project administration, and how to contribute. It also provides guidelines and best

--- a/doc/source/coding-style/deprecation.rst
+++ b/doc/source/coding-style/deprecation.rst
@@ -17,7 +17,7 @@ In the docstring of the old method, provide a `Sphinx Deprecated Directive
 that links to the new method. This way, you notify your users when you make
 an API change and give them a chance to change their code. Otherwise,
 users stop upgrading, or worse, stop using your API, due to stability concerns.
-For this reason, it's best to use a warning first and then use an error after
+For this reason, it is best to use a warning first and then use an error after
 a minor release or two.
 
 .. code:: python
@@ -48,7 +48,7 @@ a minor release or two.
             """
 
 
-If you remove a method entirely, there's no reason to provide a link to the old
+If you remove a method entirely, there is no reason to provide a link to the old
 method. Simply raise an ``AttributeError`` as part of the class or raise an ``Exception``.
 
 .. code:: python
@@ -74,7 +74,7 @@ approach is to create a custom ``DeprecationError``.
             """Empty init."""
             RuntimeError.__init__(self, message)
 
-You then use his custom ``DeprecationError`` in place of an ``Exception``.
+You then use this custom ``DeprecationError`` in place of an ``Exception``.
 
 .. code:: python
 

--- a/doc/source/coding-style/deprecation.rst
+++ b/doc/source/coding-style/deprecation.rst
@@ -1,0 +1,88 @@
+Deprecation best practices
+==========================
+While deprecation best practices are outlined in a `Stack
+Overflow Answer <https://stackoverflow.com/questions/2536307>`_ and
+in this `Deprecation library <https://deprecation.readthedocs.io/>`_ ,
+there is no official guidance on deprecating features within Python.
+Thus, this topic provides deprecation best practices for PyAnsys
+libraries. 
+
+Whenever you deprecate a method, class, or function, you must either:
+
+- Have the old method call the new method and raise a warning
+- Raise an ``AttributeError`` if you remove the method entirely
+e
+In the docstring of the old method, provide a `Sphinx Deprecated Directive
+<https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-deprecated>`_
+that links to the new method. This way, you notify your users when you make
+an API change and give them a chance to change their code. Otherwise,
+users stop upgrading, or worse, stop using your API, due to stability concerns.
+For this reason, it's best to use a warning first and then use an error after
+a minor release or two.
+
+.. code:: python
+
+    class FieldAnalysis2D():
+        """Class docstring"""
+
+        def assignmaterial(self, obj, mat):
+            """Assign a material to one or more objects.
+
+            .. deprecated:: 0.4.0
+               Use :func:`FieldAnalysis2D.assign_material` instead.
+
+            """
+            # one of the following:
+
+            # raise a DeprecationWarning. User won't have to change anything
+            warnings.warn('`assignmaterial` is deprecated. Use `assign_material` instead.',
+                          DeprecationWarning)
+            self.assign_material(obj, mat)
+
+            # or raise an AttributeError (could also make a custom DeprecationError)
+            raise AttributeError('`assignmaterial` is deprecated. Use `assign_material` instead.')
+
+        def assign_material(self, obj, mat):
+            """Assign a material to one or more objects.
+            ...
+            """
+
+
+If you remove a method entirely, there's no reason to provide a link to the old
+method. Simply raise an ``AttributeError`` as part of the class or raise an ``Exception``.
+
+.. code:: python
+
+    def hello_world():
+        """Print ``"hello_world"``
+
+        .. deprecated:: 0.4.0
+            This function has been deprecated.
+
+        """
+        raise Exception('`my_function` has been deprecated')
+
+Because there is no built-in depreciation error within Python, an alternate
+approach is to create a custom ``DeprecationError``.
+
+.. code:: python
+
+    class DeprecationError(RuntimeError):
+        """Used for depreciated methods and functions."""
+
+        def __init__(self, message='This feature has been depreciated.'):
+            """Empty init."""
+            RuntimeError.__init__(self, message)
+
+You then use his custom ``DeprecationError`` in place of an ``Exception``.
+
+.. code:: python
+
+    def hello_world():
+        """Print ``"hello_world"``
+
+        .. deprecated:: 0.4.0
+            This function has been deprecated.
+
+        """
+        raise DeprecationError('`my_function` has been deprecated.')

--- a/doc/source/coding-style/deprecation.rst
+++ b/doc/source/coding-style/deprecation.rst
@@ -11,7 +11,7 @@ Whenever you deprecate a method, class, or function, you must either:
 
 - Have the old method call the new method and raise a warning
 - Raise an ``AttributeError`` if you remove the method entirely
-e
+
 In the docstring of the old method, provide a `Sphinx Deprecated Directive
 <https://www.sphinx-doc.org/en/master/usage/restructuredtext/directives.html#directive-deprecated>`_
 that links to the new method. This way, you notify your users when you make

--- a/doc/source/coding-style/index.rst
+++ b/doc/source/coding-style/index.rst
@@ -12,7 +12,8 @@ projects.
 
 PyAnsys libraries are expected to follow `PEP 8`_ and be consistent in style and
 formatting with the 'big three' data science libraries: `NumPy`_, `SciPy`_, and
-`pandas`_.
+`pandas`_. PyAnsys libraries are also expected to follow deprecation best
+practices.
 
 .. toctree::
    :hidden:
@@ -21,6 +22,7 @@ formatting with the 'big three' data science libraries: `NumPy`_, `SciPy`_, and
    pep8
    formatting-tools
    required-standard
+   deprecation
 
 
 .. LINKS AND REFERENCES

--- a/doc/source/doc-style/docstrings.rst
+++ b/doc/source/doc-style/docstrings.rst
@@ -276,7 +276,7 @@ that are not covered here.
 Example
 =======
 
-A generic docstring example compliant with PyAnsys guidelines is shown below:
+Here is a generic docstring example compliant with PyAnsys guidelines:
 
 .. literalinclude:: code/sample_func.py
 

--- a/doc/source/doc-style/formatting-tools.rst
+++ b/doc/source/doc-style/formatting-tools.rst
@@ -129,7 +129,7 @@ it under the ``[tool.pydocstyle]`` entry:
 
 Vale
 ----
-`Vale` is a tool for maintaining a consistent style and voice in your documentation.
+`Vale`_ is a tool for maintaining a consistent style and voice in your documentation.
 Its configuration is defined in a ``.vale.ini`` file in the library's ``doc`` folder.
 For PyAnsys libraries, ``Vale`` is configured to apply the guidelines in the
 `Google developer documentation style guide <https://developers.google.com/style/>`_,
@@ -141,21 +141,21 @@ any content changes that you make in supported files locally.
 
 In the library's ``doc`` folder, download the package with:
 
-.. code-block:: python
+.. code-block:: bash
 
    vale sync
 
 Check all files in the ``doc`` folder with:
 
-.. code-block:: python
+.. code-block:: bash
 
    vale .
 
-Check all files in the repository with:
+Check all files in the repository, by going to the ``root`` directory and running:
 
-.. code-block:: python
+.. code-block:: bash
 
-   vale doc --config=doc/.vale.ini
+   vale --config=doc/.vale.ini .
 
 Check all files in only a particular folder by with  ``vale`` followed by the
 name of the folder.

--- a/doc/source/doc-style/formatting-tools.rst
+++ b/doc/source/doc-style/formatting-tools.rst
@@ -12,7 +12,6 @@ cleaner root project directory.
 
 Blacken-Docs
 ------------
-
 When writing documentation, it is frequent to include code-blocks which are used
 as examples. However, these code snippets style cannot be verified with the usual code
 formatting tools. This is where `blacken-docs`_ comes into play. You can execute
@@ -25,12 +24,11 @@ this tool by running:
 
 Codespell
 ---------
-
 `Codespell`_ checks for common misspellings in text files. This implies that it
 is not limited to Python files but can run checks on any human-readable file.
 
 It is possible to ignore words that are flagged as misspelled. You can specify these words in a
-file that can hen be passed to `Codespell` by running:
+file that can then be passed to `Codespell` by running:
 
 .. code:: bash
 
@@ -39,7 +37,6 @@ file that can hen be passed to `Codespell` by running:
 
 Docformatter
 ------------
-
 `Docformatter`_ automatically formats Python docstrings according
 to `PEP 257`_. To make sure `Docformatter`_ wraps your docstrings at a given
 number of characters, use the following configuration:
@@ -52,7 +49,6 @@ number of characters, use the following configuration:
 
 Doctest
 -------
-
 `Doctest`_ is a module from the Python standard library, which means it is
 included by default with your Python installation. It is used for checking the
 examples provided inside docstrings to make sure that they reflect the current usage
@@ -67,7 +63,6 @@ of the source code. `Doctest`_ can be integrated with ``pytest`` in :ref:`The
 
 Interrogate
 -----------
-
 `Interrogate`_ is a tool for checking docstring coverage. Similar to source code
 coverage tools, this tool tests how many functions, classes, and modules in a Python
 library hold a docstring.
@@ -119,7 +114,6 @@ validation checks
 
 Pydocstyle
 ----------
-
 `Pydocstyle`_ is a tool for checking the compliance of Python docstrings with `PEP
 257`_.  Its configuration can be defined in the :ref:`The \`\`pyproject.toml\`\`
 file`.  By default, `Pydocstyle`_ matches all ``*.py`` files except those starting with
@@ -133,12 +127,51 @@ it under the ``[tool.pydocstyle]`` entry:
    convention = "numpy"
 
 
+Vale
+----
+`Vale` is a tool for maintaining a consistent style and voice in your documentation.
+Its configuration is defined in a ``.vale.ini`` file in the library's ``doc`` folder.
+For PyAnsys libraries, ``Vale`` is configured to apply the guidelines in the
+`Google developer documentation style guide <https://developers.google.com/style/>`_,
+along with any custom Ansys rules and terminology lists, to reStructuredText (RST)
+and Markdown (MD) files.
+
+After a PyAnsys team member implements ``Vale`` in your PyAnsys library, you can check
+any content changes that you make in supported files locally.
+
+In the library's ``doc`` folder, download the package with:
+
+.. code-block:: python
+
+   vale sync
+
+Check all files in the ``doc`` folder with:
+
+.. code-block:: python
+
+   vale .
+
+Check all files in the repository with:
+
+.. code-block:: python
+
+   vale doc --config=doc/.vale.ini
+
+Check all files in only a particular folder by with  ``vale`` followed by the
+name of the folder.
+
+Address any warnings and issues that display by either editing the
+file to fix or adding a term to the ``accept.txt`` file under the 
+``doc`` folder in ``styles\Vocab\ANSYS``.
+
+
 .. _blacken-docs: https://github.com/asottile/blacken-docs
 .. _interrogate: https://interrogate.readthedocs.io/en/latest/
 .. _docstr-coverage: https://docstr-coverage.readthedocs.io/en/latest/index.html
 .. _docstring-coverage: https://bitbucket.org/DataGreed/docstring-coverage/wiki/Home
 .. _pytest-cov: https://pytest-cov.readthedocs.io/en/latest/
 .. _doctest: https://docs.python.org/3/library/doctest.html
+.. _vale: https://vale.sh/
 .. _PEP 257: http://www.python.org/dev/peps/pep-0257/
 .. _docformatter: https://github.com/PyCQA/docformatter
 .. _codespell: https://github.com/codespell-project/codespell

--- a/doc/source/doc-style/index.rst
+++ b/doc/source/doc-style/index.rst
@@ -28,6 +28,20 @@ The documentation for a PyAnsys library should contain:
 * Developer's guide for the library.
 * Link to this developer's guide.
 
+To ensure clear and consistent documentation, all PyAnsys libraries are to
+follow the guidelines in the `Google developer documentation style guide
+<https://developers.google.com/style/>`_. Key guidelines include using:
+
+- Sentence case for headings and titles
+- Active voice
+- Present tense
+- Short, clear sentences
+
+To help you follow the Google guidelines and any custom rules
+developed by Ansys, `Vale <https://vale.sh/>`_, a command-line tool that
+brings code-like linting to prose, is one of the many documentation style
+tools that can be implemented. For more information, see :ref:`Vale`.
+
 Finally, the documentation should be public and hosted via gh-pages, either as
 a branch named ``gh-pages`` within the library repository or within a
 ``gh-pages`` branch within ``<library-repository>-docs``. For more information,

--- a/doc/source/how-to/index.rst
+++ b/doc/source/how-to/index.rst
@@ -1,4 +1,4 @@
-How-To
+How-to
 ######
 
 This section describes several guidelines and best practices for creating

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -49,6 +49,7 @@ pyaedt
 PyAnsys
 pyansys
 Pydocstyle
+APIs
 PyMAPDL
 pymapdl
 PyPI


### PR DESCRIPTION
This PR adds the deprecation best practices information that is currently in the ansys_sphinx_theme repo per Issue 145 and also adds Vale information to the _PyAnsys Developer's Guide_. Once this PR is merged, I will remove the deprecation best practices information from the doc for ansys_sphinx_theme. Also, once this PR is merged, would someone please regenerate this guide. It was last regenerated on March 25!