### PR TITLE
Add section about Sphinx required configuration 

### DIFF
--- a/doc/source/doc-style/code/required_conf.py
+++ b/doc/source/doc-style/code/required_conf.py
@@ -61,9 +61,9 @@ numpydoc_validation_checks = {
     "GL10",  # reST directives {directives} must be followed by two colons
     "SS01",  # No summary found
     "SS02",  # Summary does not start with a capital letter
-    "SS03", # Summary does not end with a period
+    "SS03",  # Summary does not end with a period
     "SS04",  # Summary contains heading whitespaces
-    "SS05", # Summary must start with infinitive verb, not third person
+    "SS05",  # Summary must start with infinitive verb, not third person
     "RT02",  # The first line of the Returns section should contain only the
     # type, unless multiple values are being returned"
 }

--- a/doc/source/doc-style/code/required_conf.py
+++ b/doc/source/doc-style/code/required_conf.py
@@ -1,0 +1,85 @@
+"""Sphinx documentation configuration file."""
+from datetime import datetime
+
+from ansys_sphinx_theme import pyansys_logo_black as logo
+
+# Project information
+project = "ansys-product-library"
+copyright = f"(c) {datetime.now().year} ANSYS, Inc. All rights reserved"
+author = "ANSYS, Inc."
+release = version = "0.1.dev0"
+
+# Select desired logo, theme, and declare the html title
+html_logo = logo
+html_theme = "ansys_sphinx_theme"
+html_short_title = html_title = "pyproduct-library"
+
+# specify the location of your github repo
+html_theme_options = {
+    "github_url": "https://github.com/pyansys/pyproduct-library",
+    "show_prev_next": False,
+    "show_breadcrumbs": True,
+    "additional_breadcrumbs": [
+        ("PyAnsys", "https://docs.pyansys.com/"),
+    ],
+}
+
+# Sphinx extensions
+extensions = [
+    "sphinx.ext.autodoc",
+    "sphinx.ext.autosummary",
+    "sphinx.ext.autosectionlabel",
+    "numpydoc",
+    "sphinx.ext.intersphinx",
+    "sphinx_copybutton",
+]
+
+# Intersphinx mapping
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/dev", None),
+    # kept here as an example
+    # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
+    # "numpy": ("https://numpy.org/devdocs", None),
+    # "matplotlib": ("https://matplotlib.org/stable", None),
+    # "pandas": ("https://pandas.pydata.org/pandas-docs/stable", None),
+    # "pyvista": ("https://docs.pyvista.org/", None),
+    # "grpc": ("https://grpc.github.io/grpc/python/", None),
+}
+
+# numpydoc configuration
+numpydoc_show_class_members = False
+numpydoc_xref_param_type = True
+
+# Consider enabling numpydoc validation. See:
+# https://numpydoc.readthedocs.io/en/latest/validation.html#
+numpydoc_validate = True
+numpydoc_validation_checks = {
+    "GL06",  # Found unknown section
+    "GL07",  # Sections are in the wrong order.
+    "GL08",  # The object does not have a docstring
+    "GL09",  # Deprecation warning should precede extended summary
+    "GL10",  # reST directives {directives} must be followed by two colons
+    "SS01",  # No summary found
+    "SS02",  # Summary does not start with a capital letter
+    # "SS03", # Summary does not end with a period
+    "SS04",  # Summary contains heading whitespaces
+    # "SS05", # Summary must start with infinitive verb, not third person
+    "RT02",  # The first line of the Returns section should contain only the
+    # type, unless multiple values are being returned"
+}
+
+
+# static path
+html_static_path = ["_static"]
+
+# Add any paths that contain templates here, relative to this directory.
+templates_path = ["_templates"]
+
+# The suffix(es) of source filenames.
+source_suffix = ".rst"
+
+# The master toctree document.
+master_doc = "index"
+
+# Generate section labels up to four levels deep
+autosectionlabel_maxdepth = 4

--- a/doc/source/doc-style/code/required_conf.py
+++ b/doc/source/doc-style/code/required_conf.py
@@ -61,9 +61,9 @@ numpydoc_validation_checks = {
     "GL10",  # reST directives {directives} must be followed by two colons
     "SS01",  # No summary found
     "SS02",  # Summary does not start with a capital letter
-    # "SS03", # Summary does not end with a period
+    "SS03", # Summary does not end with a period
     "SS04",  # Summary contains heading whitespaces
-    # "SS05", # Summary must start with infinitive verb, not third person
+    "SS05", # Summary must start with infinitive verb, not third person
     "RT02",  # The first line of the Returns section should contain only the
     # type, unless multiple values are being returned"
 }

--- a/doc/source/doc-style/code/required_make.bat
+++ b/doc/source/doc-style/code/required_make.bat
@@ -1,0 +1,43 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=source
+set BUILDDIR=build
+set SPHINXOPTS=-j auto -W --keep-going
+
+if "%1" == "" goto help
+if "%1" == "pdf" goto pdf
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.http://sphinx-doc.org/
+	exit /b 1
+)
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:pdf
+	%SPHINXBUILD% -M latex %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+	cd "%BUILDDIR%\latex"
+	for %%f in (*.tex) do (
+	pdflatex "%%f" --interaction=nonstopmode)
+	
+:end
+popd

--- a/doc/source/doc-style/code/required_make.bat
+++ b/doc/source/doc-style/code/required_make.bat
@@ -12,6 +12,7 @@ set BUILDDIR=build
 set SPHINXOPTS=-j auto -W --keep-going
 
 if "%1" == "" goto help
+if "%1" == "clean" goto clean
 if "%1" == "pdf" goto pdf
 
 %SPHINXBUILD% >NUL 2>NUL
@@ -32,6 +33,11 @@ goto end
 
 :help
 %SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:clean
+rmdir /s /q %BUILDDIR% > /NUL 2>&1 
+for /d /r %SOURCEDIR% %%d in (_autosummary) do @if exist "%%d" rmdir /s /q "%%d"
+goto end
 
 :pdf
 	%SPHINXBUILD% -M latex %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%

--- a/doc/source/doc-style/code/required_makefile
+++ b/doc/source/doc-style/code/required_makefile
@@ -1,0 +1,29 @@
+# Minimal makefile for Sphinx documentation
+
+# You can set these variables from the command line.
+SPHINXOPTS    = -j auto -W --keep-going
+SPHINXBUILD   = sphinx-build
+SOURCEDIR     = source
+BUILDDIR      = build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	
+# Clean build directory files
+clean:
+	rm -rf build
+	find . -type d -name "_autosummary" -exec rm -rf {} +
+
+# Build PDF documentation
+pdf:
+	@$(SPHINXBUILD) -M latex "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+	cd build/latex && latexmk -r latexmkrc -pdf *.tex -interaction=nonstopmode || true
+	(test -f build/latex/*.pdf && echo pdf exists) || exit 1

--- a/doc/source/doc-style/code/required_makefile
+++ b/doc/source/doc-style/code/required_makefile
@@ -1,12 +1,12 @@
 # Minimal makefile for Sphinx documentation
 
-# You can set these variables from the command line.
+# You can set these variables from the command line:
 SPHINXOPTS    = -j auto -W --keep-going
 SPHINXBUILD   = sphinx-build
 SOURCEDIR     = source
 BUILDDIR      = build
 
-# Put it first so that "make" without argument is like "make help".
+# Put the "help" rule the first one so that "make" without argument behaves like "make help".
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 

--- a/doc/source/doc-style/doc-configuration.rst
+++ b/doc/source/doc-style/doc-configuration.rst
@@ -1,0 +1,66 @@
+Required Sphinx configuration
+=============================
+The following page explains the minimum required `Sphinx`_ configuration for
+building the documentation of a PyAnsys project.
+
+When installing `Sphinx`_, a program named ``sphinx-build`` gets intalled too.
+This program is in chager of collecting, parsing and rendering all the
+ReStructured Text files in :ref:`The \`\`doc/\`\` directory`.
+
+The behaviour of ``sphinx-build`` is controlled through a ``Makefile`` (to be
+used in POSIX systems) or a ``make.bat`` file (used in Windows systems). Once
+the ``sphinx-build`` command is triggered, the configuration declared in the
+``conf.py`` is applied when rendering the documentation pages. 
+
+
+The ``conf.py`` file
+--------------------
+The following code snippet collects the minimum required configuration for a
+``conf.py`` file. Custom additions should be done on top of this configuration
+to guarantee that a minimum consistency applies across different PyAnsys
+projects.
+
+.. literalinclude:: code/required_conf.py
+
+Automation files
+----------------
+As introduced at the beginning of this section, the ``sphinx-build`` program and
+all its options and arguments can be automated trhought the usage of a
+``Makefile`` file or a `make.bat`` file. These files should be placed at the
+first level of :ref:`The \`\`doc/\`\` directory`, next to the ``source/``
+directory.
+
+Notice that both files contain a ``SPHINXOPTS`` variable containing the ``-j auto -W --keep-going``:
+
+- The ``-j`` flag indicates the number of "jobs" (i.e. the number of cores to be
+  used). Default value is ``auto``, so it automatically detects the amount of
+  cores of a CPU.
+
+- The ``-W`` flag turns warnings into errors. This guarantees that documentation
+  health is maximum.
+
+- The ``--keep-going`` flag is used to render the whole documentation even if a
+  warning was found, so developers are aware about the full set of warnings.
+
+A special rule named ``pdf`` is also included. This rule is in charge of
+generating the ``PDF`` documentation of the project.
+
+
+Example ``Makefile``
+^^^^^^^^^^^^^^^^^^^^
+The following code collects the required options and automation rules to be used
+in a ``Makefile`` for building the documentation of a PyAnsys project:
+
+.. literalinclude:: code/required_makefile
+
+Example ``make.bat``
+^^^^^^^^^^^^^^^^^^^^
+The following code collects the required options and automation rules to be used
+in a ``make.bat`` for building the documentation of a PyAnsys project:
+
+.. literalinclude:: code/required_make.bat
+
+
+.. LINKS & REFERENCES:
+
+.. _Sphinx: https://www.sphinx-doc.org/en/master/

--- a/doc/source/doc-style/doc-configuration.rst
+++ b/doc/source/doc-style/doc-configuration.rst
@@ -3,11 +3,11 @@ Required Sphinx configuration
 The following page explains the minimum required `Sphinx`_ configuration for
 building the documentation of a PyAnsys project.
 
-When installing `Sphinx`_, a program named ``sphinx-build`` gets intalled too.
-This program is in chager of collecting, parsing and rendering all the
+When installing `Sphinx`_, a program named ``sphinx-build`` gets installed too.
+This program is in charge of collecting, parsing and rendering all the
 ReStructured Text files in :ref:`The \`\`doc/\`\` directory`.
 
-The behaviour of ``sphinx-build`` is controlled through a ``Makefile`` (to be
+The behavior of ``sphinx-build`` is controlled through a ``Makefile`` (to be
 used in POSIX systems) or a ``make.bat`` file (used in Windows systems). Once
 the ``sphinx-build`` command is triggered, the configuration declared in the
 ``conf.py`` is applied when rendering the documentation pages. 
@@ -25,7 +25,7 @@ projects.
 Automation files
 ----------------
 As introduced at the beginning of this section, the ``sphinx-build`` program and
-all its options and arguments can be automated trhought the usage of a
+all its options and arguments can be automated trough the usage of a
 ``Makefile`` file or a `make.bat`` file. These files should be placed at the
 first level of :ref:`The \`\`doc/\`\` directory`, next to the ``source/``
 directory.

--- a/doc/source/doc-style/doc-configuration.rst
+++ b/doc/source/doc-style/doc-configuration.rst
@@ -1,5 +1,7 @@
+<!-- vale off -->
 Required Sphinx configuration
 =============================
+<!-- vale on -->
 The following page explains the minimum required `Sphinx`_ configuration for
 building the documentation of a PyAnsys project.
 
@@ -25,7 +27,7 @@ projects.
 Automation files
 ----------------
 As introduced at the beginning of this section, the ``sphinx-build`` program and
-all its options and arguments can be automated trough the usage of a
+all its options and arguments can be automated through the usage of a
 ``Makefile`` file or a `make.bat`` file. These files should be placed at the
 first level of :ref:`The \`\`doc/\`\` directory`, next to the ``source/``
 directory.

--- a/doc/source/doc-style/doc-configuration.rst
+++ b/doc/source/doc-style/doc-configuration.rst
@@ -1,7 +1,5 @@
-<!-- vale off -->
 Required Sphinx configuration
 =============================
-<!-- vale on -->
 The following page explains the minimum required `Sphinx`_ configuration for
 building the documentation of a PyAnsys project.
 

--- a/doc/source/doc-style/index.rst
+++ b/doc/source/doc-style/index.rst
@@ -51,5 +51,6 @@ see :ref:`Deploying documentation`.
    :hidden:
    :maxdepth: 3
 
+   doc-configuration  
    docstrings
    formatting-tools

--- a/doc/source/packaging/structure.rst
+++ b/doc/source/packaging/structure.rst
@@ -138,18 +138,21 @@ building documentation for Python-based projects. As shown in :numref:`doc struc
 
 .. include:: diag/doc_structure_diag.rst
 
-- ``_build`` contains the rendered documentation in various formats, such as HTML
+- ``_build/`` contains the rendered documentation in various formats, such as HTML
   and PDF.
 
-- ``source`` contains the RST files that are used to render the documentation.
+- ``source/`` contains the RST files that are used to render the documentation.
 
 - ``make.bat`` and ``Makefile`` are used to automate cleaning and building
   commands. You use ``make.bat`` when running on Windows and ``Makefile``
-  when running on MacOS or Linux.
+  when running on MacOS or Linux. The required configuration for these files is
+  explained in the :ref:`Automation files` section.
 
 The ``source/`` directory must contain at least these files:
 
 - ``conf.py`` is a Python script used to declare the configuration of `Sphinx`_.
+  The minimum required configuration for this file is explained in :ref:`The
+  \`\`conf.py\`\` file`.
 - ``index.rst`` is the index page of the documentation. In this file, try to reuse the
   ``README.rst`` file to avoid duplication.
 

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -71,5 +71,7 @@ worktree
 Kaszynski
 Marguerin
 Maxime
+Sphinx
+sphinx
 Stephane
 grpc_chunk_stream_demo


### PR DESCRIPTION
Resolves #150 and includes example `conf.py`, `Makefile` and `make.bat` files.