### PR TITLE
Improve code sample for downloading from private PyPI.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ coverage.xml
 .hypothesis/
 .pytest_cache/
 cover/
+test-output.xml
 
 # Translations
 *.mo

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -338,7 +338,7 @@ You can download a Python package from `PyAnsys PyPI`_ by running:
 
     .. group-tab:: Linux/UNIX
 
-        .. code-block:: console
+        .. code-block:: text
 
             export INDEX_URL='https://$PYANSYS_PYPI_PRIVATE_PAT@pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/simple/'
 

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -290,6 +290,7 @@ Alternatively, instead of command-line tool arguments for Twine, you can use env
 
 
 Finally, run the following command:
+
 .. code-block:: text
 
    python -m twine upload dist/*

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -262,7 +262,7 @@ Alternatively, instead of command-line tool arguments for Twine, you can use env
 
                     set TWINE_USERNAME=<PAT>
                     set TWINE_PASSWORD=<PYANSYS_PYPI_PRIVATE_PAT>
-                    set TWINE_REPOSITORY_URL='https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload'
+                    set TWINE_REPOSITORY_URL=https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
 
             .. group-tab:: PowerShell
 
@@ -270,7 +270,7 @@ Alternatively, instead of command-line tool arguments for Twine, you can use env
 
                     $env:TWINE_USERNAME=<PAT>
                     $env:TWINE_PASSWORD=<PYANSYS_PYPI_PRIVATE_PAT>
-                    $env:TWINE_REPOSITORY_URL='https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload'
+                    $env:TWINE_REPOSITORY_URL=https://pkgs.dev.azure.com/pyansys/_packaging/pyansys/pypi/upload
 
     .. group-tab:: macOS
 


### PR DESCRIPTION
Fix twine upload code block.
Fix the TWINE_REPOSITORY_URL for Windows.

Fix #157 
Fix #158