### PR TITLE
FIX: example to match ansys-sphinx-theme>=0.8

### DIFF
--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -631,7 +631,7 @@ Mature projects configuration
 The term *mature* projects denotes those libraries which already released
 several versions. Developers of mature projects should apply previous changes
 in the ``main`` branch of their project and then *cherry-pick* these changes in
-the latests three stable release branches. This ensures that the multi-version
+the latest three stable release branches. This ensures that the multi-version
 documentation is able to function as desired.
 
 For future releases of your project, since the new ``release/X.Y`` branches are

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -588,7 +588,7 @@ The content of the ``version.json`` file should read as follows:
     ]
 
 
-- Update the version for the ``ansys-sphinx-theme`` to support ``>=0.7``.
+- Update the version for the ``ansys-sphinx-theme`` to support ``>=0.8``.
 - Include the following lines in :ref:`The \`\`conf.py\`\` file`:
 
 
@@ -596,18 +596,11 @@ The content of the ``version.json`` file should read as follows:
 
     import os
 
+    from ansys_sphinx_theme import get_version_match
+
 
     cname = os.environ.get(DOC_CNAME, "<DEFAULT_CNAME>")
     """The canonical name of the webpage hosting the documentation."""
-
-
-    def get_version_match(semver):
-        """Evaluate the version match for the multi-documentation."""
-        if semver.endswith("dev0"):
-            return "dev"
-        major, minor, _ = semver.split(".")
-        return ".".join([major, minor])
-
 
     html_theme_options = {
         "switcher": {

--- a/doc/styles/Vocab/ANSYS/accept.txt
+++ b/doc/styles/Vocab/ANSYS/accept.txt
@@ -31,6 +31,7 @@ hotfixes
 initializer
 Isort
 isort
+linenos
 matplotlib
 monospaced
 Namespace


### PR DESCRIPTION
Removes the `get_match_version` function from the multi-version documentation example. This function is already shipped with the latest ansys-sphinx-theme.