### PR TITLE
FIX: description of the versions.json file

### DIFF
--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -506,7 +506,7 @@ Follow these steps to enable multi-version documentation in your project:
 
 - Create a ``gh-pages`` branch in the repository of your project.
 
-- Create a ``release/`` directory and a ``versions.json`` containing:
+- Create a ``release/`` directory containing a ``versions.json`` file. The content of this file should be:
 
   .. code-block:: json
   


### PR DESCRIPTION
Fixes #244 by better explaining the location of the `versions.json` file.