### PR TITLE
MAINT: replace pyansys.support email with pyansys.core one

### DIFF
--- a/doc/source/getting-started/administration.rst
+++ b/doc/source/getting-started/administration.rst
@@ -110,7 +110,7 @@ Technical
 ^^^^^^^^^
 The approval of the technical guarantees that the project follows the best and
 latest software development practices. Request a technical review by sending an
-email to `pyansys.support@ansys.com <mailto:pyansys.support@ansys.com>`_.
+email to `pyansys.core@ansys.com <mailto:pyansys.core@ansys.com>`_.
 
 The following checks are required when performing the technical review of the project:
 

--- a/doc/source/getting-started/basic.rst
+++ b/doc/source/getting-started/basic.rst
@@ -61,7 +61,7 @@ particular PyAnsys library.
    style`.
 
 #. **Prepare the package for release:** When you are ready to release
-   your package publicly, email `pyansys.support@ansys.com <pyansys.support@ansys.com>`_
+   your package publicly, email `pyansys.core@ansys.com <pyansys.core@ansys.com>`_
    to obtain the release checklist for obtaining official Ansys approval.
    Once you have completed this checklist, change the `repository visibility`_
    to public and create a release branch.

--- a/doc/source/how-to/documenting.rst
+++ b/doc/source/how-to/documenting.rst
@@ -521,7 +521,7 @@ of the project.
     <https://actions.docs.pyansys.com/version/stable/doc-actions/index.html#doc-deploy-stable-action>`_.
 
 If you require support for migrating to the multi-version documentation, please
-contact ``pyansys.support@ansys.com``.
+contact ``pyansys.core@ansys.com``.
 
 
 Deploying documentation

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -426,7 +426,7 @@ public PyPI and GitHub.
 .. dropdown:: Downloading artifacts from the Ansys private PyPI
 
     Request the value of the ``PYANSYS_PYPI_PRIVATE_PAT`` token by sending an
-    email to the `pyansys.support@ansys.com <pyansys.support@ansys.com>`_ email.
+    email to the `pyansys.core@ansys.com <pyansys.core@ansys.com>`_ email.
 
     Create an environment variable named ``PYANSYS_PYPI_PRIVATE_PAT`` in your
     local machine an assign it the value of the token.

--- a/doc/source/packaging/code/pyproject_flit_code.rst
+++ b/doc/source/packaging/code/pyproject_flit_code.rst
@@ -13,7 +13,7 @@
     requires-python = ">=3.<minor>"
     license = {file = "LICENSE"}
     authors = [
-        {name = "ANSYS, Inc.", email = "pyansys.support@ansys.com"},
+        {name = "ANSYS, Inc.", email = "pyansys.core@ansys.com"},
     ]
     maintainers = [
         {name = "PyAnsys developers", email = "pyansys.maintainers@ansys.com"},

--- a/doc/source/packaging/code/pyproject_poetry_code.rst
+++ b/doc/source/packaging/code/pyproject_poetry_code.rst
@@ -10,7 +10,7 @@
     version = "<version>"
     description = "A Python wrapper for <Product> <Library>"
     license = "MIT"
-    authors = ["ANSYS, Inc. <pyansys.support@ansys.com>"]
+    authors = ["ANSYS, Inc. <pyansys.core@ansys.com>"]
     maintainers = ["PyAnsys developers <pyansys.maintainers@ansys.com>"]
     readme = "README.rst"
     repository = "https://github.com/pyansys/py<product>-<library>"

--- a/doc/source/packaging/code/setup_file_code.rst
+++ b/doc/source/packaging/code/setup_file_code.rst
@@ -13,7 +13,7 @@
         long_description=open("README.rst").read(),
         license="MIT",
         author="ANSYS, Inc.",
-        author_email="pyansys.support@ansys.com",
+        author_email="pyansys.core@ansys.com",
         maintainer="PyAnsys developers",
         maintainer_email="pyansys.maintainers@ansys.com",
         classifiers=[


### PR DESCRIPTION
Fixes #271 by replacing all the `pyansys.support@ansys.com` email references with `pyansys.core@ansys.com` ones.