### PR TITLE
Update bomanalytics url

### DIFF
--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,7 +94,7 @@ pyvista.OFF_SCREEN = True
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev", None),
-    "grantami-bomanalytics": ("https://grantami.docs.pyansys.com", None),
+    "grantami-bomanalytics": ("https://bomanalytics.grantami.docs.pyansys.com/version/stable", None),
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),
     # "matplotlib": ("https://matplotlib.org/stable", None),

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -94,7 +94,10 @@ pyvista.OFF_SCREEN = True
 # Intersphinx mapping
 intersphinx_mapping = {
     "python": ("https://docs.python.org/dev", None),
-    "grantami-bomanalytics": ("https://bomanalytics.grantami.docs.pyansys.com/version/stable", None),
+    "grantami-bomanalytics": (
+        "https://bomanalytics.grantami.docs.pyansys.com/version/stable",
+        None,
+    ),
     # "scipy": ("https://docs.scipy.org/doc/scipy/reference", None),
     # "numpy": ("https://numpy.org/devdocs", None),
     # "matplotlib": ("https://matplotlib.org/stable", None),


### PR DESCRIPTION
The documentation for bomanalytics is migrating from https://grantami.docs.pyansys.com/ to https://bomanalytics.grantami.docs.pyansys.com/

https://grantami.docs.pyansys.com/ is still the bomanalytics docs for now, but will become a general documentation page for all Granta MI PyAnsys packages.