### PR TITLE
Use twine-username argument for the release-pypi-private action.

### DIFF
--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -296,7 +296,7 @@ Replace ``<TOKEN-REDACTED>`` with the private PyPI token respectively.
               with:
                 library-name: "ansys-<product>-<library>"
                 
-                -username: "__token__"
+                twine-username: "__token__"
                 twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 
 

--- a/doc/source/how-to/releasing.rst
+++ b/doc/source/how-to/releasing.rst
@@ -295,7 +295,6 @@ Replace ``<TOKEN-REDACTED>`` with the private PyPI token respectively.
             - uses: pyansys/actions/release-pypi-private@v3
               with:
                 library-name: "ansys-<product>-<library>"
-                
                 twine-username: "__token__"
                 twine-token: ${{ secrets.PYANSYS_PYPI_PRIVATE_PAT }}
 


### PR DESCRIPTION
Fix #304 .